### PR TITLE
Add option to account for cost independent of coverage

### DIFF
--- a/Eradication/GroupEventCoordinatorHIV.cpp
+++ b/Eradication/GroupEventCoordinatorHIV.cpp
@@ -48,7 +48,7 @@ namespace Kernel
         LOG_DEBUG("GroupInterventionDistributionEventCoordinatorHIV ctor\n"); 
     } 
    
-   bool GroupInterventionDistributionEventCoordinatorHIV::visitIndividualCallback( IIndividualHumanEventContext *ihec, float& incrementalCostOut, ICampaignCostObserver* pICCO )
+   bool GroupInterventionDistributionEventCoordinatorHIV::visitIndividualCallback( IIndividualHumanEventContext *ihec, ICampaignCostObserver* pICCO )
    {
         bool retValue = true;
 
@@ -60,7 +60,7 @@ namespace Kernel
         
         demographic_restrictions.SetDemographicCoverage( dc );
         
-        retValue = StandardInterventionDistributionEventCoordinator::visitIndividualCallback( ihec, incrementalCostOut, pICCO);
+        retValue = StandardInterventionDistributionEventCoordinator::visitIndividualCallback( ihec, pICCO);
         
         return retValue;
     }

--- a/Eradication/GroupEventCoordinatorHIV.h
+++ b/Eradication/GroupEventCoordinatorHIV.h
@@ -37,7 +37,7 @@ namespace Kernel
         GroupInterventionDistributionEventCoordinatorHIV();
 
         virtual bool Configure(const Configuration* config) override;
-        virtual bool visitIndividualCallback(IIndividualHumanEventContext *ihec, float &incrementalCostOut, ICampaignCostObserver * pICCO );
+        virtual bool visitIndividualCallback(IIndividualHumanEventContext *ihec, ICampaignCostObserver * pICCO );
 
     protected:   
         float time_offset; //time used in demographic file matrix is simulation_time - time_offset

--- a/Eradication/IncidenceEventCoordinator.cpp
+++ b/Eradication/IncidenceEventCoordinator.cpp
@@ -190,7 +190,7 @@ namespace Kernel
         return INT_MAX;
     }
 
-    bool Responder::visitIndividualCallback( IIndividualHumanEventContext *ihec, float & incrementalCostOut, ICampaignCostObserver * pICCO )
+    bool Responder::visitIndividualCallback( IIndividualHumanEventContext *ihec, ICampaignCostObserver * pICCO )
     {
         release_assert( m_pCurrentAction != nullptr );
 

--- a/Eradication/IncidenceEventCoordinator.h
+++ b/Eradication/IncidenceEventCoordinator.h
@@ -96,7 +96,7 @@ namespace Kernel
         virtual void CheckConfiguration( const Configuration * inputJson );
 
         // IVisitIndividual methods
-        virtual bool visitIndividualCallback( IIndividualHumanEventContext *ihec, float & incrementalCostOut, ICampaignCostObserver * pICCO );
+        virtual bool visitIndividualCallback( IIndividualHumanEventContext *ihec, ICampaignCostObserver * pICCO );
         virtual int GetMaxEvents() const;
 
         // Other methods

--- a/Eradication/NodeEventContext.cpp
+++ b/Eradication/NodeEventContext.cpp
@@ -86,8 +86,7 @@ namespace Kernel
     {
         int   retTotal    = 0;
         int   retMax      = pEventCoordinator->GetMaxEvents();
-        float unusedVal = 0.0f;
-        
+
         std::vector<IIndividualHuman*>::iterator iter01, iterBegin, iterMid, iterEnd;
         iterBegin = node->individualHumans.begin();
         iterMid   = iterBegin;
@@ -106,7 +105,7 @@ namespace Kernel
             {
                 break;
             }
-            if(pEventCoordinator->visitIndividualCallback((*iter01)->GetEventContext(), unusedVal, this))
+            if(pEventCoordinator->visitIndividualCallback((*iter01)->GetEventContext(), this))
             {
                 retTotal++;
             }
@@ -119,7 +118,7 @@ namespace Kernel
             {
                 break;
             }
-            if(pEventCoordinator->visitIndividualCallback((*iter01)->GetEventContext(), unusedVal, this))
+            if(pEventCoordinator->visitIndividualCallback((*iter01)->GetEventContext(), this))
             {
                 retTotal++;
             }

--- a/Eradication/NodeEventContext.h
+++ b/Eradication/NodeEventContext.h
@@ -51,7 +51,7 @@ namespace Kernel
 
     struct IVisitIndividual
     {
-        virtual bool visitIndividualCallback(IIndividualHumanEventContext* ihec, float& incrementalCostOut, ICampaignCostObserver* pICCO ) = 0;
+        virtual bool visitIndividualCallback(IIndividualHumanEventContext* ihec, ICampaignCostObserver* pICCO ) = 0;
         virtual int  GetMaxEvents() const = 0;
     };
 

--- a/Eradication/StandardEventCoordinator.cpp
+++ b/Eradication/StandardEventCoordinator.cpp
@@ -41,6 +41,7 @@ namespace Kernel
     StandardInterventionDistributionEventCoordinator::StandardInterventionDistributionEventCoordinator( bool useDemographicCoverage ) 
         : parent(nullptr)
         , distribution_complete(false)
+        , m_cost_for_everybody(false)
         , num_repetitions(1)
         , tsteps_between_reps(-1)
         , tsteps_since_last(0)
@@ -73,6 +74,8 @@ namespace Kernel
         demographic_restrictions.ConfigureRestrictions( this, inputJson );
 
         initConfigComplexType( "Node_Property_Restrictions", &node_property_restrictions, SEC_Node_Property_Restriction_DESC_TEXT );
+
+        initConfigTypeMap( "Cost_Assumes_Total_Coverage", &m_cost_for_everybody, SEC_Cost_Assumes_Total_Coverage_DESC_TEXT, false );
 
         bool retValue = JsonConfigurable::Configure( inputJson );
         if( retValue && !JsonConfigurable::_dryrun)
@@ -230,9 +233,9 @@ namespace Kernel
         return ihec->GetInterventionsContext()->GetParent()->GetRng()->SmartDraw( demographic_coverage );
     }
 
-    bool StandardInterventionDistributionEventCoordinator::visitIndividualCallback( IIndividualHumanEventContext* ihec, float& incrementalCostOut, ICampaignCostObserver* pICCO )
+    bool StandardInterventionDistributionEventCoordinator::visitIndividualCallback( IIndividualHumanEventContext* ihec, ICampaignCostObserver* pICCO )
     {
-        bool distributed = true;
+        bool distributed = false;
 
         // Add real checks on demographics based on intervention demographic targetting. 
         // Return immediately if we hit a non-distribute condition
@@ -245,13 +248,15 @@ namespace Kernel
 
         if (!TargetedIndividualIsCovered(ihec))
         {
-            incrementalCostOut = 0;
-            return false;
+            if (m_cost_for_everybody && pICCO)
+            {
+                pICCO->notifyCampaignExpenseIncurred( m_pInterventionIndividual->GetCostPerUnit(), ihec );
+                ihec->GetInterventionsContext();
+            }
         }
         else
         {
-            incrementalCostOut = 0;
-            distributed = DistributeInterventionsToIndividual( ihec, incrementalCostOut, pICCO );
+            distributed = DistributeInterventionsToIndividual( ihec, pICCO );
         }
 
         return distributed;
@@ -304,23 +309,16 @@ namespace Kernel
         return demographic_restrictions.GetMaximumAge();
     }
 
-    void StandardInterventionDistributionEventCoordinator::ProcessDeparting(
-        IIndividualHumanEventContext *pInd
-    )
+    void StandardInterventionDistributionEventCoordinator::ProcessDeparting( IIndividualHumanEventContext *pInd )
     {
         LOG_INFO("Individual departing from node receiving intervention. TODO: enforce demographic and other qualifiers.\n");
-        float incrementalCostOut = 0.0f;
-        visitIndividualCallback( pInd, incrementalCostOut, nullptr /* campaign cost observer */ );
+        visitIndividualCallback( pInd, nullptr /* campaign cost observer */ );
     } // these do nothing for now
 
-    void
-    StandardInterventionDistributionEventCoordinator::ProcessArriving(
-        IIndividualHumanEventContext *pInd
-    )
+    void StandardInterventionDistributionEventCoordinator::ProcessArriving( IIndividualHumanEventContext *pInd )
     {
         LOG_INFO("Individual arriving at node receiving intervention. TODO: enforce demographic and other qualifiers.\n");
-        float incrementalCostOut = 0.0f; 
-        visitIndividualCallback( pInd, incrementalCostOut, nullptr /* campaign cost observer */ );
+        visitIndividualCallback( pInd, nullptr /* campaign cost observer */ );
     }
 
     void StandardInterventionDistributionEventCoordinator::DistributeInterventionsToNodes( INodeEventContext* event_context )
@@ -353,9 +351,7 @@ namespace Kernel
         }
     }
 
-    bool StandardInterventionDistributionEventCoordinator::DistributeInterventionsToIndividual( IIndividualHumanEventContext *ihec,
-                                                                                                float & incrementalCostOut,
-                                                                                                ICampaignCostObserver * pICCO )
+    bool StandardInterventionDistributionEventCoordinator::DistributeInterventionsToIndividual( IIndividualHumanEventContext *ihec, ICampaignCostObserver *pICCO )
     {
         // instantiate and distribute intervention
         LOG_DEBUG_F( "Attempting to instantiate intervention of class %s\n", log_intervention_name.c_str());
@@ -368,8 +364,7 @@ namespace Kernel
 
         if( distributed )
         {
-            LOG_DEBUG_F( "Distributed an intervention (%p) to individual %d at a cost of %f\n",
-                    di->GetName().c_str(), ihec->GetSuid().data, incrementalCostOut );
+            LOG_DEBUG_F( "Distributed an intervention (%p) to individual %d\n", di->GetName().c_str(), ihec->GetSuid().data);
         }
         return distributed;
     }

--- a/Eradication/StandardEventCoordinator.cpp
+++ b/Eradication/StandardEventCoordinator.cpp
@@ -251,7 +251,6 @@ namespace Kernel
             if (m_cost_for_everybody && pICCO)
             {
                 pICCO->notifyCampaignExpenseIncurred( m_pInterventionIndividual->GetCostPerUnit(), ihec );
-                ihec->GetInterventionsContext();
             }
         }
         else

--- a/Eradication/StandardEventCoordinator.h
+++ b/Eradication/StandardEventCoordinator.h
@@ -44,7 +44,7 @@ namespace Kernel
 
         virtual void Update(float dt);
         virtual void UpdateNodes(float dt);
-        virtual bool visitIndividualCallback(IIndividualHumanEventContext *ihec, float &incrementalCostOut, ICampaignCostObserver * pICCO );
+        virtual bool visitIndividualCallback(IIndividualHumanEventContext *ihec, ICampaignCostObserver * pICCO );
 
         virtual bool IsFinished(); // returns true when the EC requires no further updates and can be disposed of
 
@@ -71,7 +71,6 @@ namespace Kernel
         virtual void DistributeInterventionsToNodes( INodeEventContext* event_context );
         virtual void DistributeInterventionsToIndividuals( INodeEventContext* event_context );
         virtual bool DistributeInterventionsToIndividual( IIndividualHumanEventContext *ihec,
-                                                          float & incrementalCostOut,
                                                           ICampaignCostObserver * pICCO );
         // helpers
         void regenerateCachedNodeContextPointers();
@@ -79,6 +78,7 @@ namespace Kernel
 
         ISimulationEventContext  *parent;
         bool distribution_complete;
+        bool m_cost_for_everybody;
         int num_repetitions;
         int tsteps_between_reps;
         int tsteps_since_last;

--- a/campaign/Interventions.h
+++ b/campaign/Interventions.h
@@ -65,6 +65,8 @@ namespace Kernel
         virtual bool NeedsInfectiousLoopUpdate() const = 0;
         virtual bool NeedsPreInfectivityUpdate() const = 0;
 
+        virtual float GetCostPerUnit() const = 0;
+
         virtual IDrug*                     GetDrug()             = 0;
         virtual IMalariaDrugEffects*       GetMalariaDrug()      = 0;
         virtual IHealthSeekingBehavior*    GetHSB()              = 0;
@@ -130,13 +132,8 @@ namespace Kernel
         virtual bool GiveIntervention( INodeDistributableIntervention * pIV ) = 0;
     };
 
-    struct IDMAPI IBaseIntervention : ISupports
-    {
-        virtual float GetCostPerUnit() const = 0;
-    };
-
     // TODO - BaseInterventions looks concrete, but can't be instantiated. :(
-    struct IDMAPI BaseIntervention : IDistributableIntervention, IBaseIntervention, JsonConfigurable
+    struct IDMAPI BaseIntervention : IDistributableIntervention, JsonConfigurable
     {
         IMPLEMENT_DEFAULT_REFERENCE_COUNTING()
 
@@ -181,14 +178,13 @@ namespace Kernel
         EventTrigger::Enum event_trigger_expired;
     };
 
-    struct BaseNodeIntervention : INodeDistributableIntervention, IBaseIntervention, JsonConfigurable
+    struct BaseNodeIntervention : INodeDistributableIntervention, JsonConfigurable
     {
         IMPLEMENT_DEFAULT_REFERENCE_COUNTING()
 
     public:
         virtual bool Configure( const Configuration* inputJson ) override;
         virtual const std::string& GetName() const override { return name; };
-        virtual float GetCostPerUnit() const override { return cost_per_unit; }
         virtual bool Expired() override;
         virtual void SetExpired( bool isExpired ) override;
         virtual void OnExpiration() override;

--- a/componentTests/INodeEventContextFake.h
+++ b/componentTests/INodeEventContextFake.h
@@ -141,11 +141,10 @@ public:
 
     virtual int VisitIndividuals(IVisitIndividual* pIndividualVisitImpl)
     { 
-        float cost = 0.0;
         int count = 0;
         for( auto p_human : m_HumanList )
         {
-            if( pIndividualVisitImpl->visitIndividualCallback( p_human->GetEventContext(), cost, nullptr ) )
+            if( pIndividualVisitImpl->visitIndividualCallback( p_human->GetEventContext(), nullptr ) )
             {
                 ++count;
             }

--- a/interventions/InputEIR.cpp
+++ b/interventions/InputEIR.cpp
@@ -96,14 +96,4 @@ namespace Kernel
         release_assert(inmie);
         inmie->ChallengeWithInfectiousBites(1, daily_EIR, risk_function);
     }
-
-    float InputEIR::GetCostPerUnit() const
-    {
-        // -------------------------------------------------------------------------------
-        // --- Since this intervention is used to infect people in absence of mosquitos,
-        // --- it doesn't have a cost associated with it.
-        // -------------------------------------------------------------------------------
-        return 0.0;
-    }
-
 }

--- a/interventions/InputEIR.h
+++ b/interventions/InputEIR.h
@@ -36,8 +36,6 @@ namespace Kernel
         virtual bool Configure(const Configuration* config) override;
         virtual void Update(float dt) override;
 
-        // IBaseIntervention
-        virtual float GetCostPerUnit() const override;
     protected:
         AgeDependentBitingRisk::Enum age_dependence;
         std::vector<float> monthly_EIR; // 12 values of EIR by month

--- a/utils/iv_params.rc
+++ b/utils/iv_params.rc
@@ -444,6 +444,7 @@
 #define SD_Positive_Diagnosis_Config_Event_DESC_TEXT "If the test is positive, this specifies an event that can trigger another intervention when the event occurs. Only used if Event_Or_Config is set to Event."
 #define SD_Treatment_Fraction_DESC_TEXT "The fraction of positive diagnoses that are treated."
 #define SEC_Coordinator_Name_DESC_TEXT "The unique identifying coordinator name, which is useful with the output report, ReportSurveillanceEventRecorder.csv."
+#define SEC_Cost_Assumes_Total_Coverage_DESC_TEXT "Individual intervention cost applies to all individuals in target demographic and ignores coverage."
 #define SEC_Demographic_Coverage_DESC_TEXT "The fraction of individuals in the target demographic that are counted."
 #define SEC_Duration_DESC_TEXT "The number of days from when the surveillance event coordinator was created by the campaign event. Once the number of days has passed, the delay event coordinator will unregister for events and expire. The default value of '-1' = never expire."
 #define SEC_Incidence_Counter_DESC_TEXT "List of JSON objects for specifying the conditions and parameters that must be met for an incidence to be counted."


### PR DESCRIPTION
New parameter **Cost_Assumes_Total_Coverage** added to standard event coordinator, which increments campaign cost for all individuals in the target demographic and ignores coverage
