### PR TITLE
Format cleanup 2

### DIFF
--- a/docs/md_dev/dev-install-build-emod.md
+++ b/docs/md_dev/dev-install-build-emod.md
@@ -48,24 +48,26 @@ custom SCons abilities just for EMOD.
 
 1. Open a Command Prompt window.
 
-1. Go to the directory where EMOD is installed::
+1. Go to the directory where EMOD is installed:
 
+      ```
         cd C:\IDM\EMOD
+      ```
 
 1. Run the following command to build Eradication.exe:
 
-    * For a monolithic build:
+      * For a monolithic build:
 
-```
-        scons --Release
-```
+      ```
+            scons --Release
+      ```
 
-    * For a disease-specific build, specify one of the supported disease types using the
-      `--Disease` flag:
+     * For a disease-specific build, specify one of the supported disease types using the
+    `--Disease` flag:
 
-```
-        scons --Release --Disease=Vector
-```
+      ```
+              scons --Release --Disease=Vector
+      ```
 
 1. The executable will be placed, by default, in the subdirectory
     build\\x64\\Release\\Eradication\\ of your local EMOD source.

--- a/docs/md_dev/dev-sft.md
+++ b/docs/md_dev/dev-sft.md
@@ -14,15 +14,13 @@ If you are running locally without access to an HPC, do one the following depend
 
 1. In the Regression directory, edit the regression_test.cfg file to list the directories where you want the simulations to be run and output saved.
 
-1. Make a file listing all of the SFTs you want to run, using on of the files in Regression\<sim>_science.json as an example.
+1. Make a file listing all of the SFTs you want to run, using one of the files in Regression\\&lt;sim>_science.json as an example.
 
-1. From the Regression directory in a command prompt window, run the following, adding `--scons` if you built the Eradication.exe using SCONS::
+2. From the Regression directory in a command prompt window, run the following, adding `--scons` if you built the Eradication.exe using SCons:
 
         python regression_test.py my_sfts.json --local
 
-!!! note
-
-            Enter `python regression_test.py --help` for a list of all arguments you can use with the testing script.
+      - Enter `python regression_test.py --help` for a list of all arguments you can use with the testing script.
 
 ### Run on Windows using run_test.cmd
 
@@ -30,16 +28,11 @@ If you are running locally without access to an HPC, do one the following depend
 
 1. Navigate to the directory that contains your config.json file and other test files.
 
-!!! note
+      - Verify in the config.json file that the paths to the demographics and other additional input files are correct.
 
-            Verify in the config.json file that the paths to the demographics and other additional input files are correct.
+2. In a command prompt window, enter the following, substituting your path to the testing script as necessary:
 
-1. In a command prompt window, enter the following, substituting your path to the testing script 
-    as necessary:
-
-```
-        ../../run_test.cmd
-```
+                ../../run_test.cmd
 
 ### Run on CentOS using run_test.sh
 
@@ -47,13 +40,8 @@ If you are running locally without access to an HPC, do one the following depend
 
 1. Navigate to the directory that contains your config.json file and other test files.
 
-!!! note
+      - Verify in the config.json file that the paths to the demographics and other additional input files are correct.
 
-            Verify in the config.json file that the paths to the demographics and other additional input files are correct.
+2. In a command prompt window, enter the following, substituting your path to the testing script as necessary:
 
-1. In a command prompt window, enter the following, substituting your path to the testing script
-    as necessary:
-
-```
-        ../../run_test.sh
-```
+                ../../run_test.sh

--- a/docs/md_parameter/parameter-demographics.md
+++ b/docs/md_parameter/parameter-demographics.md
@@ -40,8 +40,6 @@ The tables below contain only parameters available when using the generic **simu
         information to your files. Any keys that are not EMOD parameter names will be ignored by the
         model.
 
-    <button class="collapse-table-button btn btn-info">Collapse all parameter tables</button>
-
 ## Metadata
 
 Metadata provides information about data provenance. **IdReference** is the
@@ -53,15 +51,14 @@ in valid JSON format.
 If you generate **input files** using COMPS, the following **IdReference** values are
 possible and indicate how the **NodeID** values are generated:
 
-Gridded world grump30arcsec
-    Nodes are approximately square regions defined by a 30-arc second grid and the **NodeID** values
-    are generated from the latitude and longitude of the northwest corner.
-Gridded world grump2.5arcmin
-    Nodes are approximately square regions defined by a 2.5-arc minute grid and the **NodeID** values
-    are generated from the latitude and longitude of the northwest corner.
-Gridded world grump1degree
-    Nodes are approximately square regions defined by a 1-degree grid and the **NodeID** values are
-    generated from the latitude and longitude of the northwest corner.
+Gridded world grump30arcsec: Nodes are approximately square regions defined by a 30-arc second grid and the **NodeID** values
+are generated from the latitude and longitude of the northwest corner.
+
+Gridded world grump2.5arcmin: Nodes are approximately square regions defined by a 2.5-arc minute grid and the **NodeID** values
+are generated from the latitude and longitude of the northwest corner.
+
+Gridded world grump1degree: Nodes are approximately square regions defined by a 1-degree grid and the **NodeID** values are
+generated from the latitude and longitude of the northwest corner.
 
 The algorithm for encoding latitude and longitude into a **NodeID** is as follows:
 
@@ -74,8 +71,6 @@ The algorithm for encoding latitude and longitude into a **NodeID** is as follow
 This generates a **NodeID** that is a 4-byte unsigned integer; the first two bytes represent the
 longitude of the node and the second two bytes represent the latitude. To reserve 0 to be used as a
 null value, 1 is added to the **NodeID** as part of the final calculation.
-
-    <button class="toggle-button btn btn-info">Toggle parameter table</button>
 
 {{ read_csv("csv/demo-metadata-generic.csv") }}
 
@@ -98,19 +93,13 @@ that contains parameters that assign properties to nodes in a simulation. The
 **IndividualProperties** section is under either **Defaults** or **Nodes** and contains parameters
 that assign properties to individuals in a simulation. [model-properties](../md_model/model-properties.md) provides more guidance.
 
-    <button class="toggle-button btn btn-info">Toggle parameter table</button>
-
 {{ read_csv("csv/demo-properties-generic.csv") }}
-
-.. _demo-nodeattributes:
 
 ## NodeAttributes
 
 The **NodeAttributes** section contains parameters that add or modify information
 regarding the location, migration, habitat, and population of node. Some **NodeAttributes**
 depend on values set in the configuration parameters.
-
-    <button class="toggle-button btn btn-info">Toggle parameter table</button>
 
 {{ read_csv("csv/demo-nodeattributes-generic.csv") }}
 
@@ -123,8 +112,6 @@ configured using a simple flag system of three parameters or a complex system of
 many more parameters. The following table contains the parameters that can be used with either
 distribution system.
 
-    <button class="toggle-button btn btn-info">Toggle parameter table</button>
-
 {{ read_csv("csv/demo-individualattributes-generic.csv") }}
 
 ### Complex distributions
@@ -134,7 +121,5 @@ where the distribution does not fit a standard. Individual attribute values are 
 linear distribution. The distribution is configured using arrays of axes (such as gender or age) and
 values at points along each of these axes. This allows you to have different distributions for
 different groups in the population.
-
-    <button class="toggle-button btn btn-info">Toggle parameter table</button>
 
 {{ read_csv("csv/demo-complexdistro-generic.csv") }}

--- a/docs/md_parameter/parameter-schema.md
+++ b/docs/md_parameter/parameter-schema.md
@@ -26,35 +26,34 @@ The following command-line options are available for providing information about
 ## Usage
 
 1. Open a Command Prompt window and navigate to the directory where Eradication.exe is installed.
-1. To output the schema to the Command Prompt window, enter::
+1. To output the schema to the Command Prompt window, enter:
 
-        Eradication.exe --get-schema
+    ```
+                Eradication.exe --get-schema
+    ```
 
-1. To output the schema to a file, do one of the following (replacing <filename> with the
-    desired filename):
+1. To output the schema to a file, do one of the following (replacing &lt;filename> with the desired filename}:
 
-    *   To output a text file that includes logging information, enter:
+    * To output a text file that includes logging information, enter:
+  
+        ```
+                     Eradication.exe --get-schema > <filename>.txt
+        ```
 
-```
-            Eradication.exe --get-schema > <filename>.txt
-```
+     * To display logging in the Command Prompt window and output a text file that does not include logging information, enter:
 
-    *   To display logging in the Command Prompt window and output a text file
-        that does not include logging information, enter:
+        ```
+                     Eradication.exe --get-schema --schema-path <filename>.txt
+        ``` 
 
-```
-            Eradication.exe --get-schema --schema-path <filename>.txt
-```
+     * To output the schema to a JSON file that includes logging information, enter:
 
-    *   To output the schema to a JSON file that includes logging information, enter:
+        ```
+                     Eradication.exe --get-schema > <filename>.json
+        ```
 
-```
-            Eradication.exe --get-schema > <filename>.json
-```
+     * To display logging in the Command Prompt window and output a JSON file that does not include logging information, enter:
 
-    *   To display logging in the Command Prompt window and output a JSON file
-        that does not include logging information, enter:
-
-```
-            Eradication.exe --get-schema --schema-path <filename>.json
-```
+        ```
+                     Eradication.exe --get-schema --schema-path <filename>.json
+        ```

--- a/docs/md_software/software-campaign.md
+++ b/docs/md_software/software-campaign.md
@@ -18,19 +18,19 @@ file is specified by **Campaign_Filename** in the configuration file.
 
 To distribute an intervention, you must configure the following nested JSON objects:
 
-campaign event
+## campaign event
 
 Campaign events determine *when* and *where* an intervention is distributed during a campaign. "When"
 can be the number of days after the beginning of the simulation or at a point during a particular
 calendar year. "Where" is the geographic **node** or nodes in which the event takes place.
 
-event coordinator
+## event coordinator
 
 Event coordinators are nested within the campaign event JSON object and determine *who* receives the
 intervention. "Who" is determined by filtering on age, gender, or on the individual properties
 configured in the demographics files, such as risk group or sociodemographic category. See [model-properties](../md_model/model-properties.md).
 
-individual-level intervention
+## individual-level intervention
 
 Individual-level interventions determine *what* will be distributed to individuals to reduce the
 spread of a disease. For example, distributing vaccines or drugs are individual-level interventions.
@@ -50,7 +50,7 @@ the intervention is received. For example, you can assign a property value after
 first-line treatment for a disease and prevent anyone from receiving the second-line treatment
 unless they have that property value and are still symptomatic.
 
-node-level intervention
+## node-level intervention
 
 Node-level interventions determine *what* will be distributed to each **node** to reduce the spread of a
 disease. For example, spraying larvicide in a village to kill mosquito larvae is a node-level malaria

--- a/docs/md_software/software-campaign.md
+++ b/docs/md_software/software-campaign.md
@@ -18,19 +18,19 @@ file is specified by **Campaign_Filename** in the configuration file.
 
 To distribute an intervention, you must configure the following nested JSON objects:
 
-## campaign event
+## Campaign event
 
 Campaign events determine *when* and *where* an intervention is distributed during a campaign. "When"
 can be the number of days after the beginning of the simulation or at a point during a particular
 calendar year. "Where" is the geographic **node** or nodes in which the event takes place.
 
-## event coordinator
+## Event coordinator
 
 Event coordinators are nested within the campaign event JSON object and determine *who* receives the
 intervention. "Who" is determined by filtering on age, gender, or on the individual properties
 configured in the demographics files, such as risk group or sociodemographic category. See [model-properties](../md_model/model-properties.md).
 
-## individual-level intervention
+## Individual-level intervention
 
 Individual-level interventions determine *what* will be distributed to individuals to reduce the
 spread of a disease. For example, distributing vaccines or drugs are individual-level interventions.
@@ -50,7 +50,7 @@ the intervention is received. For example, you can assign a property value after
 first-line treatment for a disease and prevent anyone from receiving the second-line treatment
 unless they have that property value and are still symptomatic.
 
-## node-level intervention
+## Node-level intervention
 
 Node-level interventions determine *what* will be distributed to each **node** to reduce the spread of a
 disease. For example, spraying larvicide in a village to kill mosquito larvae is a node-level malaria


### PR DESCRIPTION
-Corrected formatting for numbered lists with embedded bullets/code boxes on 3 pages.

-Removed broken table toggle/collapse buttons on parameter-demographics. I didn't see these buttons in use anywhere else, so I thought it was safe to remove them. Let me know if you'd like to fix them instead. 
We discussed the broken .. _demo-nodeattributes: on this doc via chat - removed it for now but I'll replace it with a working version in a future commit, along with two on other docs (WIP).

-Added sub-headers in software-campaign for readability. Tried as bold too, but this seemed most clear.

-Also caught a couple instances w/ angled brackets being treated incorrectly and fixed them.